### PR TITLE
Rearrange week 2 runs

### DIFF
--- a/data/week_002.json
+++ b/data/week_002.json
@@ -11,27 +11,27 @@
     },
     {
       "date": "2025-02-12",
+      "type": "Easy Run",
+      "distance": 7,
+      "notes": "Easy Run 7km at 6:30-7:00/km pace. Recovery effort - should feel very comfortable after yesterday's longer run."
+    },
+    {
+      "date": "2025-02-13",
       "type": "Long Run",
       "distance": 18,
       "notes": "Long Run 18km at 6:15-6:45/km pace. Take water and consider energy gel at 12km. Start very easy first 2-3km then settle into pace."
     },
     {
-      "date": "2025-02-14",
+      "date": "2025-02-15",
       "type": "Quality",
       "distance": 10,
       "notes": "Quality Session: Total 10km as follows: 2km warmup (7:00/km pace), 3 x 2km at tempo pace (5:45-6:00/km) with 800m easy jog recovery (7:00+/km) between sets, 2km cooldown (7:00+/km pace). Dynamic stretches before start, focus on form during tempo sections."
     },
     {
-      "date": "2025-02-15",
+      "date": "2025-02-16",
       "type": "Medium Long Run",
       "distance": 11,
       "notes": "Medium Long Run 11km at 6:30-6:45/km pace. Take water if needed. Focus on maintaining consistent pace throughout."
-    },
-    {
-      "date": "2025-02-16",
-      "type": "Easy Run",
-      "distance": 7,
-      "notes": "Easy Run 7km at 6:30-7:00/km pace. Recovery effort - should feel very comfortable after yesterday's longer run."
     }
   ]
 }


### PR DESCRIPTION
This PR rearranges the runs in week 2 as follows:
- Moves Sunday's Easy Run (7km) to Wednesday
- Shifts Long Run from Wednesday to Thursday
- Shifts Quality session from Friday to Saturday
- Shifts Medium Long Run from Saturday to Sunday

No changes were made to the content of any runs (type, distance, notes remain the same).