### PR TITLE
Update week 2 running schedule

### DIFF
--- a/data/week_002.json
+++ b/data/week_002.json
@@ -17,21 +17,21 @@
     },
     {
       "date": "2025-02-13",
+      "type": "Easy Run",
+      "distance": 5,
+      "notes": "Easy Run 5km at 6:30-7:00/km pace. Keep effort relaxed and controlled throughout."
+    },
+    {
+      "date": "2025-02-15",
       "type": "Long Run",
       "distance": 18,
       "notes": "Long Run 18km at 6:15-6:45/km pace. Take water and consider energy gel at 12km. Start very easy first 2-3km then settle into pace."
     },
     {
-      "date": "2025-02-15",
+      "date": "2025-02-16",
       "type": "Quality",
       "distance": 10,
       "notes": "Quality Session: Total 10km as follows: 2km warmup (7:00/km pace), 3 x 2km at tempo pace (5:45-6:00/km) with 800m easy jog recovery (7:00+/km) between sets, 2km cooldown (7:00+/km pace). Dynamic stretches before start, focus on form during tempo sections."
-    },
-    {
-      "date": "2025-02-16",
-      "type": "Medium Long Run",
-      "distance": 11,
-      "notes": "Medium Long Run 11km at 6:30-6:45/km pace. Take water if needed. Focus on maintaining consistent pace throughout."
     }
   ]
 }


### PR DESCRIPTION
This PR updates the week 2 running schedule with the following changes:

1. Move Thursday's 18km Long Run to Saturday
2. Add new Easy Run 5km on Thursday
3. Move Saturday's Quality Session to Sunday
4. Remove Sunday's Medium Long Run

New schedule:
- Mon 10 Feb: Rest day
- Tue 11 Feb: Easy Run 8km
- Wed 12 Feb: Easy Run 7km
- Thu 13 Feb: Easy Run 5km (new)
- Fri 14 Feb: Rest day
- Sat 15 Feb: Long Run 18km (moved from Thu)
- Sun 16 Feb: Quality Session 10km (moved from Sat)
