### PR TITLE
Update training schedule for weeks 2 and 3

### DIFF
--- a/data/week_002.json
+++ b/data/week_002.json
@@ -26,12 +26,6 @@
       "type": "Long Run",
       "distance": 18,
       "notes": "Long Run 18km at 6:15-6:45/km pace. Take water and consider energy gel at 12km. Start very easy first 2-3km then settle into pace."
-    },
-    {
-      "date": "2025-02-16",
-      "type": "Quality",
-      "distance": 10,
-      "notes": "Quality Session: Total 10km as follows: 2km warmup (7:00/km pace), 3 x 2km at tempo pace (5:45-6:00/km) with 800m easy jog recovery (7:00+/km) between sets, 2km cooldown (7:00+/km pace). Dynamic stretches before start, focus on form during tempo sections."
     }
   ]
 }

--- a/data/week_003.json
+++ b/data/week_003.json
@@ -4,13 +4,19 @@
   "stats": {},
   "runs": [
     {
-      "date": "2025-02-18",
+      "date": "2025-02-17",
+      "type": "Quality",
+      "distance": 10,
+      "notes": "Quality Session: Total 10km as follows: 2km warmup (7:00/km pace), 3 x 2km at tempo pace (5:45-6:00/km) with 800m easy jog recovery (7:00+/km) between sets, 2km cooldown (7:00+/km pace). Dynamic stretches before start, focus on form during tempo sections."
+    },
+    {
+      "date": "2025-02-19",
       "type": "Easy Run",
       "distance": 9,
       "notes": "Easy Run 9km at 6:30-7:00/km pace. Keep effort relaxed, focus on good form even when tired."
     },
     {
-      "date": "2025-02-19",
+      "date": "2025-02-20",
       "type": "Long Run",
       "distance": 20,
       "notes": "Long Run 20km at 6:15-6:45/km pace. Take water bottle/hydration pack. Energy gel at 8km and 15km. First 3km easy, then settle into pace. Practice race day morning routine including breakfast."


### PR DESCRIPTION
This PR makes the following changes to the training schedule:

1. Week 2:
   - Removed Sunday's quality session (10km)

2. Week 3:
   - Added Monday quality session (moved from week 2)
   - Shifted easy run to Wednesday
   - Moved long run to Thursday
   - Kept Friday-Sunday schedule unchanged

These changes maintain appropriate recovery between harder sessions while preserving the overall training structure.