### PR TITLE
Update training plan for weeks 3-4 with actual runs

### DIFF
--- a/data/week_003.json
+++ b/data/week_003.json
@@ -23,15 +23,15 @@
     },
     {
       "date": "2025-02-22",
-      "type": "Medium Long Run",
-      "distance": 12,
-      "notes": "Medium Long Run 12km at 6:30-6:45/km pace. Take water if needed. Focus on maintaining consistent pace and good form even with accumulated fatigue."
+      "type": "Rest",
+      "distance": 0,
+      "notes": "Rest Day. Focus on recovery with light stretching if desired."
     },
     {
       "date": "2025-02-23",
-      "type": "Quality",
-      "distance": 11,
-      "notes": "Quality Session: Total 11km as follows: 2km warmup (7:00/km pace), 5km continuous tempo (5:45-6:00/km pace), then 3km at marathon pace (6:10-6:20/km), 1km easy cooldown (7:00+/km). Dynamic stretches before start. This session introduces marathon pace to get familiar with target race effort."
+      "type": "Medium Long Run",
+      "distance": 12,
+      "notes": "Medium Long Run 12km at 6:30-6:45/km pace. Take water if needed. Focus on maintaining consistent pace and good form even with accumulated fatigue."
     }
   ]
 }

--- a/data/week_004.json
+++ b/data/week_004.json
@@ -12,8 +12,8 @@
     {
       "date": "2025-02-26",
       "type": "Long Run",
-      "distance": 22,
-      "notes": "Long Run 22km at 6:15-6:45/km pace. Include 2 x 3km at marathon pace (6:10-6:20/km) at 10km and 16km marks. Take water and energy gels at 8km and 16km. Be strict about not running marathon pace segments too fast - practicing exact race pace builds specific endurance needed for race day. Track morning heart rate tomorrow to monitor recovery."
+      "distance": 17,
+      "notes": "Long Run 17km at 6:15-6:45/km pace. Include 2 x 3km at marathon pace (6:10-6:20/km) at 10km and 16km marks. Take water and energy gels at 8km. Be strict about not running marathon pace segments too fast - practicing exact race pace builds specific endurance needed for race day. Track morning heart rate tomorrow to monitor recovery."
     },
     {
       "date": "2025-02-27",
@@ -24,8 +24,8 @@
     {
       "date": "2025-02-28",
       "type": "Easy Run",
-      "distance": 7,
-      "notes": "Easy Run 7km at 6:30-7:00/km pace. Keep effort very relaxed - this is a recovery run after your long run. Consider adding 15-20 minutes of strength work focusing on running-specific movements: single leg squats, calf raises, planks and hip exercises after the run."
+      "distance": 10,
+      "notes": "Easy Run 10km at 6:30-7:00/km pace. Keep effort very relaxed - this is a recovery run after your long run. Consider adding 15-20 minutes of strength work focusing on running-specific movements: single leg squats, calf raises, planks and hip exercises after the run."
     },
     {
       "date": "2025-03-01",
@@ -35,9 +35,9 @@
     },
     {
       "date": "2025-03-02",
-      "type": "Quality",
-      "distance": 9,
-      "notes": "Hill Repeats: Total 9km as follows: 2km warmup (7:00/km pace), 5 x 3 min uphill efforts with jog down recovery, 2km cooldown (7:00+/km). Choose a moderate grade hill (4-6%) that allows you to maintain good form throughout. Effort should feel hard but sustainable for 3 minutes (approximately 5:30-5:45/km effort on flat ground)."
+      "type": "Easy Run",
+      "distance": 10,
+      "notes": "Easy Run 10km at 6:30-7:00/km pace. Keep effort relaxed and controlled throughout."
     }
   ]
 }


### PR DESCRIPTION
This PR updates the marathon training plan with actual runs completed in weeks 3 and 4:

## Week 3 Changes:
- **Saturday (Feb 22):** Changed from a 12km Medium Long Run to a Rest Day
- **Sunday (Feb 23):** Changed from an 11km Quality Session to a 12km Medium Long Run (moved from Saturday)

## Week 4 Changes:
- **Wednesday (Feb 26):** Reduced Long Run distance from 22km to 17km
- **Friday (Feb 28):** Increased Easy Run distance from 7km to 10km
- **Sunday (Mar 2):** Changed from a 9km Hill Repeats session to a 10km Easy Run

These changes reflect the actual training completed during these weeks.