### PR TITLE
Add ability to track actual vs planned workouts

### DIFF
--- a/css/run-card.css
+++ b/css/run-card.css
@@ -55,3 +55,13 @@
     font-size: 0.9rem;
     margin-top: 0.5rem;
 }
+
+.planned-run {
+    margin-bottom: 12px;
+}
+
+.actual-run {
+    margin-top: 12px;
+    padding-top: 10px;
+    border-top: 1px solid var(--border-color);
+}

--- a/data/week_005.json
+++ b/data/week_005.json
@@ -7,43 +7,57 @@
       "date": "2025-03-03",
       "type": "Rest Day",
       "distance": 0,
-      "notes": "Rest Day. Optional light mobility work or gentle yoga. Focus on recovery after your hill session yesterday."
+      "planned": "Rest Day. Optional light mobility work or gentle yoga. Focus on recovery after your hill session yesterday.",
+      "actualDistance": null,
+      "actual": null
     },
     {
       "date": "2025-03-04",
       "type": "Easy Run",
       "distance": 9,
-      "notes": "Easy Run 9km at 6:30-7:00/km pace. Keep effort controlled throughout. If you're interested in tracking recovery, note your morning heart rate today and compare with normal baseline."
+      "planned": "Easy Run 9km at 6:30-7:00/km pace. Keep effort controlled throughout. If you're interested in tracking recovery, note your morning heart rate today and compare with normal baseline.",
+      "actualDistance": 8.5,
+      "actual": "Felt a bit tired so kept it shorter. Average pace was 6:45/km. Resting HR was 52bpm this morning, slightly elevated from baseline."
     },
     {
       "date": "2025-03-05",
       "type": "Long Run",
       "distance": 24,
-      "notes": "Long Run 24km at 6:15-6:45/km with 5km at marathon pace (6:10-6:20/km) from 14-19km. Take water and energy gels at 8km and 16km. Use this run to experiment systematically with your race-day nutrition strategy - test different gel/drink combinations you plan to use on race day. Pay attention to how your body responds during the marathon pace segment."
+      "planned": "Long Run 24km at 6:15-6:45/km with 5km at marathon pace (6:10-6:20/km) from 14-19km. Take water and energy gels at 8km and 16km. Use this run to experiment systematically with your race-day nutrition strategy - test different gel/drink combinations you plan to use on race day. Pay attention to how your body responds during the marathon pace segment.",
+      "actualDistance": 26.2,
+      "actual": "Felt strong today so extended a bit. Hit the marathon pace section well (avg 6:15/km). Maurten gels at 8km and 16km worked well with no GI issues. Might try taking one at 24km on the next long run to simulate late-race fueling."
     },
     {
       "date": "2025-03-06",
       "type": "Rest Day",
       "distance": 0,
-      "notes": "Rest Day. Focus on hydration and recovery after yesterday's long run. Optional recovery swim or yoga if desired."
+      "planned": "Rest Day. Focus on hydration and recovery after yesterday's long run. Optional recovery swim or yoga if desired.",
+      "actualDistance": null,
+      "actual": null
     },
     {
       "date": "2025-03-07",
       "type": "Easy Run",
       "distance": 8,
-      "notes": "Easy Run + Strides 8km at 6:30-7:00/km pace. Add 6 x 100m strides at the end of the run (fast but relaxed form). Consider adding 15-20 minutes of strength work focusing on running-specific movements: single leg squats, calf raises, planks and hip exercises after the run."
+      "planned": "Easy Run + Strides 8km at 6:30-7:00/km pace. Add 6 x 100m strides at the end of the run (fast but relaxed form). Consider adding 15-20 minutes of strength work focusing on running-specific movements: single leg squats, calf raises, planks and hip exercises after the run.",
+      "actualDistance": 8,
+      "actual": "Completed as planned. Felt recovered after the long run. Did strength work afterward - planks, lunges, and calf raises."
     },
     {
       "date": "2025-03-08",
       "type": "Medium Long Run",
       "distance": 13,
-      "notes": "Medium-Long Hill Run 13km at 6:30-6:45/km on flats, effort-based on hills. Progressive effort - last 4km slightly faster if feeling good. Aim for moderate hills (4-6% grade) to maintain good running form. Focus on strong hill running technique and use downhills to practice controlled form that will help prevent quad fatigue on race day."
+      "planned": "Medium-Long Hill Run 13km at 6:30-6:45/km on flats, effort-based on hills. Progressive effort - last 4km slightly faster if feeling good. Aim for moderate hills (4-6% grade) to maintain good running form. Focus on strong hill running technique and use downhills to practice controlled form that will help prevent quad fatigue on race day.",
+      "actualDistance": 12.7,
+      "actual": "Good hill session. Found a new route with some challenging climbs. Quads feeling it on the downhills, but form stayed solid. Last 4km at 6:20/km pace."
     },
     {
       "date": "2025-03-09",
       "type": "Quality",
       "distance": 11,
-      "notes": "Hill + Tempo Session: Total 11km as follows: 2km warmup, 4 x 3 min hill efforts with jog down recovery, 3km tempo run (5:45-6:00/km pace), 2km cooldown. This complex session builds strength through hills first, then challenges you to maintain tempo pace on slightly fatigued legs - excellent marathon-specific training."
+      "planned": "Hill + Tempo Session: Total 11km as follows: 2km warmup, 4 x 3 min hill efforts with jog down recovery, 3km tempo run (5:45-6:00/km pace), 2km cooldown. This complex session builds strength through hills first, then challenges you to maintain tempo pace on slightly fatigued legs - excellent marathon-specific training.",
+      "actualDistance": 10.5,
+      "actual": "Modified today's session due to light rain. Did 3 hill repeats instead of 4, but completed the full tempo portion at 5:50/km pace. Legs felt good considering yesterday's effort."
     }
   ]
 }

--- a/data/week_005_backup.json
+++ b/data/week_005_backup.json
@@ -1,0 +1,49 @@
+{
+  "weekNumber": 5,
+  "startDate": "2025-03-03",
+  "stats": {"targetDistance": "60-63"},
+  "runs": [
+    {
+      "date": "2025-03-03",
+      "type": "Rest Day",
+      "distance": 0,
+      "notes": "Rest Day. Optional light mobility work or gentle yoga. Focus on recovery after your hill session yesterday."
+    },
+    {
+      "date": "2025-03-04",
+      "type": "Easy Run",
+      "distance": 9,
+      "notes": "Easy Run 9km at 6:30-7:00/km pace. Keep effort controlled throughout. If you're interested in tracking recovery, note your morning heart rate today and compare with normal baseline."
+    },
+    {
+      "date": "2025-03-05",
+      "type": "Long Run",
+      "distance": 24,
+      "notes": "Long Run 24km at 6:15-6:45/km with 5km at marathon pace (6:10-6:20/km) from 14-19km. Take water and energy gels at 8km and 16km. Use this run to experiment systematically with your race-day nutrition strategy - test different gel/drink combinations you plan to use on race day. Pay attention to how your body responds during the marathon pace segment."
+    },
+    {
+      "date": "2025-03-06",
+      "type": "Rest Day",
+      "distance": 0,
+      "notes": "Rest Day. Focus on hydration and recovery after yesterday's long run. Optional recovery swim or yoga if desired."
+    },
+    {
+      "date": "2025-03-07",
+      "type": "Easy Run",
+      "distance": 8,
+      "notes": "Easy Run + Strides 8km at 6:30-7:00/km pace. Add 6 x 100m strides at the end of the run (fast but relaxed form). Consider adding 15-20 minutes of strength work focusing on running-specific movements: single leg squats, calf raises, planks and hip exercises after the run."
+    },
+    {
+      "date": "2025-03-08",
+      "type": "Medium Long Run",
+      "distance": 13,
+      "notes": "Medium-Long Hill Run 13km at 6:30-6:45/km on flats, effort-based on hills. Progressive effort - last 4km slightly faster if feeling good. Aim for moderate hills (4-6% grade) to maintain good running form. Focus on strong hill running technique and use downhills to practice controlled form that will help prevent quad fatigue on race day."
+    },
+    {
+      "date": "2025-03-09",
+      "type": "Quality",
+      "distance": 11,
+      "notes": "Hill + Tempo Session: Total 11km as follows: 2km warmup, 4 x 3 min hill efforts with jog down recovery, 3km tempo run (5:45-6:00/km pace), 2km cooldown. This complex session builds strength through hills first, then challenges you to maintain tempo pace on slightly fatigued legs - excellent marathon-specific training."
+    }
+  ]
+}

--- a/js/elements.js
+++ b/js/elements.js
@@ -3,20 +3,46 @@ import { formatDistance } from './units.js';
 import { CLASSES, RUN_TYPES } from './constants.js';
 
 function createWeekSummary(week, weekNumber, totalWeeks, useKm) {
-    const actualRuns = week.runs.filter(run => run.type !== RUN_TYPES.REST);
-    const totalDistance = actualRuns.reduce((sum, run) => sum + run.distance, 0);
-    const distance = formatDistance(totalDistance, useKm);
+    const actualRuns = week.runs.filter(run => run.type !== RUN_TYPES.REST && run.type !== 'Rest Day');
+    
+    // Calculate planned total distance
+    const plannedTotalDistance = actualRuns.reduce((sum, run) => sum + (run.distance || 0), 0);
+    
+    // Calculate actual total distance if available
+    const hasActualDistances = actualRuns.some(run => run.actualDistance !== undefined && run.actualDistance !== null);
+    
+    let actualTotalDistance = 0;
+    if (hasActualDistances) {
+        actualTotalDistance = actualRuns.reduce((sum, run) => {
+            // If actual distance is available for this run, use it, otherwise use planned
+            const distanceToAdd = (run.actualDistance !== undefined && run.actualDistance !== null) 
+                ? run.actualDistance 
+                : (run.distance || 0);
+            return sum + distanceToAdd;
+        }, 0);
+    }
+    
+    const plannedDistance = formatDistance(plannedTotalDistance, useKm);
+    const actualDistance = formatDistance(actualTotalDistance, useKm);
 
     const summaryEl = document.createElement('div');
     summaryEl.className = CLASSES.WEEK_SUMMARY;
 
     const weeksUntilRace = totalWeeks - weekNumber;
 
+    // Choose the appropriate distance display format
+    let distanceDisplay = '';
+    if (hasActualDistances) {
+        distanceDisplay = `Planned / completed distance: ${plannedDistance} / ${actualDistance} km`;
+    } else {
+        distanceDisplay = `Weekly distance: ${plannedDistance} km`;
+    }
+
     summaryEl.innerHTML = `
         <div class="week-summary-title">Week ${weekNumber} of ${totalWeeks}</div>
         <div class="week-progress">${getDateRange(week)}</div>
         <div class="countdown">${weeksUntilRace} week(s) until race day</div>
-        <div class="total-distance">Weekly distance: ${distance} km</div>
+        <div class="total-distance">${distanceDisplay}</div>
     `;
 
     return summaryEl;
@@ -24,19 +50,40 @@ function createWeekSummary(week, weekNumber, totalWeeks, useKm) {
 
 function createDayElement(day, useKm) {
     const dayEl = document.createElement('div');
-    dayEl.className = CLASSES.RUN_CARD + (day.type === RUN_TYPES.REST ? ` ${CLASSES.REST_DAY}` : '');
+    dayEl.className = CLASSES.RUN_CARD + (day.type === RUN_TYPES.REST || day.type === 'Rest Day' ? ` ${CLASSES.REST_DAY}` : '');
     
-    const distance = day.distance ? formatDistance(day.distance, useKm) : 0;
+    // Get planned and actual distances
+    const plannedDistance = day.distance ? formatDistance(day.distance, useKm) : 0;
+    const hasActualDistance = day.actualDistance !== undefined && day.actualDistance !== null;
+    const actualDistance = hasActualDistance ? formatDistance(day.actualDistance, useKm) : null;
+    
+    // Determine distance display text
+    let distanceDisplay = plannedDistance;
+    if (hasActualDistance && Math.abs(day.distance - day.actualDistance) > 0.1) {
+        distanceDisplay = `${plannedDistance} km (actual: ${actualDistance} km)`;
+    } else if (plannedDistance > 0) {
+        distanceDisplay = `${plannedDistance} km`;
+    }
+    
+    // Get planned and actual notes (supporting both note formats)
+    const plannedNotes = day.planned || day.notes || '';
+    const actualNotes = day.actual || '';
+    
     dayEl.innerHTML = `
         <div class="run-date">${formatDate(day.date)}</div>
         <div class="run-type">${day.type}</div>
-        ${distance > 0 ? `
+        ${plannedDistance > 0 ? `
             <div class="stat">
-                <div class="stat-value">${distance} km</div>
+                <div class="stat-value">${distanceDisplay}</div>
                 <div class="stat-label">Distance</div>
             </div>
         ` : ''}
-        ${day.notes ? `<div class="run-notes">${day.notes}</div>` : ''}
+        ${plannedNotes ? `
+            <div class="run-notes">
+                <div class="planned-run"><strong>Planned:</strong> ${plannedNotes}</div>
+                ${actualNotes ? `<div class="actual-run"><strong>Notes:</strong> ${actualNotes}</div>` : ''}
+            </div>
+        ` : ''}
     `;
     
     return dayEl;


### PR DESCRIPTION
This PR adds the ability to track both planned and actual workout information to the marathon training tracker.

## Features
- Added support for tracking actual distances vs planned distances
- Added ability to enter notes about completed workouts
- Updated weekly summary to show both planned and completed distances
- Modified distance display to show both values when they differ
- Added visual separation between planned and actual sections

## Implementation Details
- Updated `elements.js` to create run cards with both planned and actual sections
- Modified weekly distance calculation in `createWeekSummary()` to include both totals
- Added styling for new planned/actual sections in `run-card.css`
- Updated week 5 JSON file as an example with sample data
- Created a backup of the original week 5 data

## Data Structure
The JSON format has been extended with new fields:
```json
{
  "date": "2025-03-04",
  "type": "Easy Run",
  "distance": 9,          // planned distance
  "planned": "Easy Run...", // planned workout (replaces "notes")
  "actualDistance": 8.5,   // actual distance run (optional)
  "actual": "Felt a bit tired..." // actual workout notes (optional)
}
```

## Backward Compatibility
The code remains compatible with the existing JSON format. If `planned` and `actual` fields don't exist, it will fall back to using the `notes` field.
